### PR TITLE
Implement password change on profile page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Status: Production Ready
 ## Feature Roadmap
 - Tune Mastery Level calculations
 - Update User Profile statistics
-- Add password reset functionality
+- Add password reset functionality (profile page)
 - Add individual question and section statistics
 
 ## Development Setup

--- a/backend/quizapp/urls.py
+++ b/backend/quizapp/urls.py
@@ -10,7 +10,8 @@ urlpatterns = [
     path('auth/logout/', views.logout_user, name='logout_user'),  
     path('auth/profile/', views.update_user_profile, name='update_user_profile'), 
     path('auth/password-reset/', views.reset_password_request, name='reset_password_request'),  
-    path('auth/password-reset/confirm/', views.reset_password_confirm, name='reset_password_confirm'),  
+    path('auth/password-reset/confirm/', views.reset_password_confirm, name='reset_password_confirm'),
+    path('auth/change-password/', views.change_password, name='change_password'),
     path('auth/save-options/', views.get_user_account_save_options, name='user_save_options'),  
     
     # File Management

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -20,6 +20,12 @@ const Profile = () => {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const [profileData, setProfileData] = useState(null);
+  const [passwordForm, setPasswordForm] = useState({
+    currentPassword: '',
+    newPassword: '',
+    confirmPassword: ''
+  });
+  const [showPasswordForm, setShowPasswordForm] = useState(false);
 
   // Fetch complete user profile data
   React.useEffect(() => {
@@ -100,6 +106,38 @@ const Profile = () => {
     setEditing(false);
     setError('');
     setSuccess('');
+  };
+
+  const handlePasswordChange = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    setSuccess('');
+
+    if (passwordForm.newPassword !== passwordForm.confirmPassword) {
+      setError('New passwords do not match');
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const response = await axios.post('/api/auth/change-password/', {
+        current_password: passwordForm.currentPassword,
+        new_password: passwordForm.newPassword
+      });
+      if (response.data.success) {
+        setSuccess('Password changed successfully!');
+        setShowPasswordForm(false);
+        setPasswordForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
+      }
+    } catch (err) {
+      console.error('Failed to change password:', err);
+      setError(
+        err.response?.data?.error || 'Failed to change password'
+      );
+    } finally {
+      setLoading(false);
+    }
   };
 
   // Show loading while auth is being initialized
@@ -283,7 +321,79 @@ const Profile = () => {
           )}
         </div>
 
-        {/* Account Statistics */}
+        {/* Change Password */}
+        <div className="card">
+          <h2>Change Password</h2>
+          {!showPasswordForm ? (
+            <button
+              className="btn btn-secondary"
+              onClick={() => setShowPasswordForm(true)}
+            >
+              Update Password
+            </button>
+          ) : (
+            <form onSubmit={handlePasswordChange} style={{ marginTop: '1rem' }}>
+              <div className="form-group">
+                <label htmlFor="currentPassword">Current Password</label>
+                <input
+                  type="password"
+                  id="currentPassword"
+                  name="currentPassword"
+                  value={passwordForm.currentPassword}
+                  onChange={e =>
+                    setPasswordForm(prev => ({ ...prev, currentPassword: e.target.value }))
+                  }
+                  required
+                />
+              </div>
+              <div className="form-group">
+                <label htmlFor="newPassword">New Password</label>
+                <input
+                  type="password"
+                  id="newPassword"
+                  name="newPassword"
+                  value={passwordForm.newPassword}
+                  onChange={e =>
+                    setPasswordForm(prev => ({ ...prev, newPassword: e.target.value }))
+                  }
+                  required
+                />
+              </div>
+              <div className="form-group">
+                <label htmlFor="confirmPassword">Confirm New Password</label>
+                <input
+                  type="password"
+                  id="confirmPassword"
+                  name="confirmPassword"
+                  value={passwordForm.confirmPassword}
+                  onChange={e =>
+                    setPasswordForm(prev => ({ ...prev, confirmPassword: e.target.value }))
+                  }
+                  required
+                />
+              </div>
+              <div style={{ display: 'flex', gap: '1rem' }}>
+                <button type="submit" className="btn btn-primary" disabled={loading}>
+                  {loading ? 'Updating...' : 'Change Password'}
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  onClick={() => {
+                    setShowPasswordForm(false);
+                    setPasswordForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
+                    setError('');
+                    setSuccess('');
+                  }}
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          )}
+        </div>
+
+      {/* Account Statistics */}
         <div className="card">
           <h2>Account Statistics</h2>
           


### PR DESCRIPTION
## Summary
- enable password changes via new POST `/auth/change-password/` endpoint
- hook up profile UI to allow users to update their password
- document the new capability in the roadmap

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686b09be202883249dd37ffd0c9ef6cd