### PR TITLE
Integrate password change into profile card

### DIFF
--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -321,12 +321,12 @@ const Profile = () => {
           )}
         </div>
 
-        {/* Change Password */}
-        <div className="card">
-          <h2>Change Password</h2>
-          {!showPasswordForm ? (
+        {/* Password Change (embedded in personal info card) */}
+        {editing && (
+          !showPasswordForm ? (
             <button
               className="btn btn-secondary"
+              style={{ marginTop: '1rem' }}
               onClick={() => setShowPasswordForm(true)}
             >
               Update Password
@@ -390,8 +390,8 @@ const Profile = () => {
                 </button>
               </div>
             </form>
-          )}
-        </div>
+          )
+        )}
 
       {/* Account Statistics */}
         <div className="card">


### PR DESCRIPTION
## Summary
- embed password update flow directly in the Personal Information card
- remove the separate Change Password card

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `python manage.py test` *(fails: couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_686b0c0c315483248b916444366e870c