### PR TITLE
Allow custom quiz timer values

### DIFF
--- a/frontend/src/pages/QuizLanding.js
+++ b/frontend/src/pages/QuizLanding.js
@@ -298,7 +298,7 @@ const QuizLanding = () => {
               if (e.target.value === 'custom') {
                 const val = window.prompt('Enter timer in minutes');
                 if (val && !isNaN(val)) {
-                  setTimerMinutes(parseInt(val, 10));
+                  setTimerMinutes(String(parseInt(val, 10)));
                 } else {
                   setTimerMinutes('none');
                 }
@@ -313,6 +313,11 @@ const QuizLanding = () => {
             <option value="30">30</option>
             <option value="60">60</option>
             <option value="custom">Custom...</option>
+            {!["none", "1", "15", "30", "60", "custom"].includes(String(timerMinutes)) && (
+              <option value={timerMinutes} hidden>
+                Custom ({timerMinutes} min)
+              </option>
+            )}
           </select>
         </div>
         <button onClick={startQuiz} className="btn btn-primary" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', justifyContent: 'center' }}>


### PR DESCRIPTION
## Summary
- improve timer dropdown to keep custom timer selections

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686b2938a3408324aa6e6b169e3430e3