### PR TITLE
Fix duplicate params declaration in Quiz.js

### DIFF
--- a/frontend/src/pages/Quiz.js
+++ b/frontend/src/pages/Quiz.js
@@ -81,7 +81,6 @@ const Quiz = () => {
         setAttemptId(attemptResponse.data.data.attempt_id);
         
         // Set timer if quiz has time limit
-        const params = new URLSearchParams(location.search);
         const customTimer = parseInt(params.get('timer'), 10);
         
         if (!isNaN(customTimer) && customTimer > 0) {


### PR DESCRIPTION
## Summary
- remove duplicate `params` declaration in Quiz.js to fix ESLint build error

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687144c362088324b6cb5de796f19e57