### PR TITLE
Add section metrics page and tooltips

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -415,4 +415,40 @@ body {
   visibility: visible;
 }
 
+.section-metrics-container {
+  position: relative;
+  display: inline-block;
+}
+
+.section-metrics-tooltip {
+  visibility: hidden;
+  background-color: #2c3e50;
+  color: #fff;
+  text-align: left;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  position: absolute;
+  z-index: 10;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  font-size: 0.8rem;
+}
+
+.section-metrics-container:hover .section-metrics-tooltip {
+  visibility: visible;
+}
+
+.section-metrics-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: #2c3e50 transparent transparent transparent;
+}
+
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import Upload from './pages/Upload';
 import Quiz from './pages/Quiz';
 import Profile from './pages/Profile';
 import QuizLanding from './pages/QuizLanding';
+import SectionMetrics from './pages/SectionMetrics';
 import { AuthProvider } from './services/AuthContext';
 
 function App() {
@@ -28,6 +29,7 @@ function App() {
               <Route path="/dashboard" element={<Dashboard />} />
               <Route path="/upload" element={<Upload />} />
               <Route path="/quiz/:id" element={<QuizLanding />} />
+              <Route path="/quiz/:id/metrics" element={<SectionMetrics />} />
               <Route path="/quiz/:id/take" element={<Quiz />} />
               <Route path="/profile" element={<Profile />} />
             </Routes>

--- a/frontend/src/pages/QuizLanding.js
+++ b/frontend/src/pages/QuizLanding.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../services/AuthContext';
 import { BookOpen, Clock, BarChart3, PlayCircle, TrendingUp, Edit2, Edit3, X, Check } from 'lucide-react';
 import axios from 'axios';
@@ -327,7 +327,16 @@ const QuizLanding = () => {
       </div>
       <div className="card" style={{ marginTop: '2rem' }}>
         <h3 style={{ marginTop: 0 }}>Sections</h3>
-        {sections.map((section) => (
+        {hasSections && (
+          <div style={{ textAlign: 'right', marginBottom: '1rem' }}>
+            <Link to={`/quiz/${id}/metrics`} className="btn btn-secondary btn-small">
+              View Section Metrics
+            </Link>
+          </div>
+        )}
+        {sections.map((section) => {
+          const sectionInfo = stats?.section_stats?.find((s) => s.section_id === section.section_id);
+          return (
           <div key={section.section_id} style={{ marginBottom: '2rem' }}>
             {editingSection && editingSection.section_id === section.section_id ? (
               <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
@@ -357,7 +366,19 @@ const QuizLanding = () => {
                 style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '0.5rem' }}
               >
                 <div>
-                  <h4 style={{ margin: '0 0 0.25rem 0' }}>{section.name}</h4>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+                    <h4 style={{ margin: '0 0 0.25rem 0' }}>{section.name}</h4>
+                    {sectionInfo && (
+                      <span className="section-metrics-container">
+                        <BarChart3 size={16} style={{ color: '#3498db', cursor: 'pointer' }} />
+                        <span className="section-metrics-tooltip">
+                          {sectionInfo.question_count} questions
+                          <br />
+                          Accuracy: {sectionInfo.accuracy}%
+                        </span>
+                      </span>
+                    )}
+                  </div>
                   <p style={{ color: '#7f8c8d', margin: 0 }}>{section.description}</p>
                 </div>
                 <div style={{ display: 'flex', gap: '0.25rem' }}>
@@ -452,7 +473,8 @@ const QuizLanding = () => {
               ))}
             </div>
           </div>
-        ))}
+        );
+        })}
       </div>
     </div>
   );

--- a/frontend/src/pages/SectionMetrics.js
+++ b/frontend/src/pages/SectionMetrics.js
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../services/AuthContext';
+import axios from 'axios';
+import { ArrowLeft, BarChart3 } from 'lucide-react';
+
+axios.defaults.baseURL = 'https://api.quizcanvas.xyz';
+
+const SectionMetrics = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const { isAuthenticated, loading: authLoading } = useAuth();
+  const [stats, setStats] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!isAuthenticated) {
+      navigate('/login');
+      return;
+    }
+
+    const fetchStats = async () => {
+      try {
+        setLoading(true);
+        const res = await axios.get(`/api/quizzes/${id}/statistics/`);
+        if (res.data.success) {
+          setStats(res.data.data);
+        } else {
+          setError('Failed to load section metrics');
+        }
+      } catch (err) {
+        setError('Failed to load section metrics');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchStats();
+  }, [id, isAuthenticated, authLoading, navigate]);
+
+  if (authLoading || loading) {
+    return (
+      <div className="page">
+        <div className="loading">
+          <div className="spinner"></div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="page">
+        <div className="error-message">{error}</div>
+      </div>
+    );
+  }
+
+  const { quiz, section_stats } = stats || {};
+
+  return (
+    <div className="page">
+      <div style={{ marginBottom: '1rem' }}>
+        <Link to={`/quiz/${id}`} className="btn" style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+          <ArrowLeft size={16} /> Back
+        </Link>
+      </div>
+      <h1>{quiz?.title} - Section Metrics</h1>
+      {section_stats && section_stats.length > 0 ? (
+        <div className="card">
+          {section_stats.map((section) => (
+            <div key={section.section_id} style={{ marginBottom: '1rem', display: 'flex', justifyContent: 'space-between' }}>
+              <div>
+                <strong>{section.name}</strong>
+                <div style={{ color: '#7f8c8d' }}>{section.question_count} questions</div>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+                <BarChart3 size={16} />
+                <span>{section.accuracy}% accuracy</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p>No sections available.</p>
+      )}
+    </div>
+  );
+};
+
+export default SectionMetrics;


### PR DESCRIPTION
## Summary
- add dedicated route `/quiz/:id/metrics` with new `SectionMetrics` page
- show a link on the landing page to view section metrics
- display a bar chart icon next to each section with tooltip info
- style tooltip in `App.css`

## Testing
- `npm test` *(fails: `npm: command not found`)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6871498601a4832488f8f3dd9a9af396