### PR TITLE
Add forgot password workflow

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,6 +6,8 @@ import Home from './pages/Home';
 import FAQ from './pages/FAQ';
 import Login from './pages/Login';
 import Register from './pages/Register';
+import ForgotPassword from './pages/ForgotPassword';
+import ResetPassword from './pages/ResetPassword';
 import Dashboard from './pages/Dashboard';
 import Upload from './pages/Upload';
 import Quiz from './pages/Quiz';
@@ -26,6 +28,8 @@ function App() {
               <Route path="/faq" element={<FAQ />} />
               <Route path="/login" element={<Login />} />
               <Route path="/register" element={<Register />} />
+              <Route path="/forgot-password" element={<ForgotPassword />} />
+              <Route path="/reset-password/:token" element={<ResetPassword />} />
               <Route path="/dashboard" element={<Dashboard />} />
               <Route path="/upload" element={<Upload />} />
               <Route path="/quiz/:id" element={<QuizLanding />} />

--- a/frontend/src/pages/FAQ.js
+++ b/frontend/src/pages/FAQ.js
@@ -105,7 +105,7 @@ const FAQ = () => {
         },
         {
           question: "What if I forget my password?",
-          answer: "Password resets are not currently available and will be implemented in future development"
+          answer: "Use the \"Forgot Password\" link on the login page to request a reset email. You'll be able to set a new password using the link provided."
         },
         {
           question: "Can I delete my account?",

--- a/frontend/src/pages/ForgotPassword.js
+++ b/frontend/src/pages/ForgotPassword.js
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+import { useAuth } from '../services/AuthContext';
+import { Mail, RotateCw } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+const ForgotPassword = () => {
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
+  const [loading, setLoading] = useState(false);
+  const { requestPasswordReset } = useAuth();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setMessage('');
+    setLoading(true);
+
+    const result = await requestPasswordReset(email);
+
+    if (result.success) {
+      setMessage(result.message || 'If an account with that email exists, you will receive a reset link.');
+    } else {
+      setError(result.error);
+    }
+
+    setLoading(false);
+  };
+
+  return (
+    <div className="page">
+      <div className="form-container">
+        <div style={{ textAlign: 'center', marginBottom: '2rem' }}>
+          <RotateCw size={48} style={{ color: '#3498db', marginBottom: '1rem' }} />
+          <h1>Forgot Password</h1>
+          <p style={{ color: '#7f8c8d' }}>Enter your account email to reset your password</p>
+        </div>
+
+        {error && (
+          <div className="error-message">
+            {error}
+          </div>
+        )}
+
+        {message && (
+          <div className="success-message">
+            {message}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label htmlFor="email">
+              <Mail size={16} style={{ display: 'inline', marginRight: '0.5rem' }} />
+              Email Address
+            </label>
+            <input
+              type="email"
+              id="email"
+              name="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              placeholder="Enter your email"
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="btn btn-primary btn-full-width"
+            disabled={loading}
+          >
+            {loading ? 'Submitting...' : 'Send Reset Link'}
+          </button>
+        </form>
+
+        <div style={{ textAlign: 'center', marginTop: '2rem' }}>
+          <Link to="/login" style={{ color: '#3498db', textDecoration: 'none', fontSize: '0.9rem' }}>
+            Back to login
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ForgotPassword;

--- a/frontend/src/pages/ResetPassword.js
+++ b/frontend/src/pages/ResetPassword.js
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import { useAuth } from '../services/AuthContext';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { Lock } from 'lucide-react';
+
+const ResetPassword = () => {
+  const { token } = useParams();
+  const navigate = useNavigate();
+  const { resetPassword } = useAuth();
+  const [formData, setFormData] = useState({ newPassword: '', confirmPassword: '' });
+  const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setMessage('');
+
+    if (formData.newPassword !== formData.confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+
+    setLoading(true);
+    const result = await resetPassword(token, formData.newPassword);
+    if (result.success) {
+      setMessage(result.message || 'Password reset successfully. Redirecting to login...');
+      setTimeout(() => navigate('/login'), 2000);
+    } else {
+      setError(result.error);
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="page">
+      <div className="form-container">
+        <div style={{ textAlign: 'center', marginBottom: '2rem' }}>
+          <Lock size={48} style={{ color: '#3498db', marginBottom: '1rem' }} />
+          <h1>Reset Password</h1>
+          <p style={{ color: '#7f8c8d' }}>Enter a new password for your account</p>
+        </div>
+
+        {error && (
+          <div className="error-message">{error}</div>
+        )}
+        {message && (
+          <div className="success-message">{message}</div>
+        )}
+
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label htmlFor="newPassword">
+              <Lock size={16} style={{ display: 'inline', marginRight: '0.5rem' }} />
+              New Password
+            </label>
+            <input
+              type="password"
+              id="newPassword"
+              name="newPassword"
+              value={formData.newPassword}
+              onChange={handleChange}
+              required
+              placeholder="Enter new password"
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="confirmPassword">
+              <Lock size={16} style={{ display: 'inline', marginRight: '0.5rem' }} />
+              Confirm Password
+            </label>
+            <input
+              type="password"
+              id="confirmPassword"
+              name="confirmPassword"
+              value={formData.confirmPassword}
+              onChange={handleChange}
+              required
+              placeholder="Confirm new password"
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="btn btn-primary btn-full-width"
+            disabled={loading}
+          >
+            {loading ? 'Updating...' : 'Reset Password'}
+          </button>
+        </form>
+
+        <div style={{ textAlign: 'center', marginTop: '2rem' }}>
+          <Link to="/login" style={{ color: '#3498db', textDecoration: 'none', fontSize: '0.9rem' }}>
+            Back to login
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ResetPassword;

--- a/frontend/src/services/AuthContext.js
+++ b/frontend/src/services/AuthContext.js
@@ -169,10 +169,53 @@ export const AuthProvider = ({ children }) => {
     }
   };
 
+  const requestPasswordReset = async (email) => {
+    try {
+      setLoading(true);
+      const response = await axios.post('/api/auth/password-reset/', { email });
+      if (response.data.success) {
+        return { success: true, message: response.data.message };
+      }
+      return { success: false, error: response.data.error || 'Password reset request failed' };
+    } catch (error) {
+      console.error('Password reset request failed:', error);
+      return {
+        success: false,
+        error: error.response?.data?.error || 'Password reset request failed'
+      };
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const resetPassword = async (token, newPassword) => {
+    try {
+      setLoading(true);
+      const response = await axios.post('/api/auth/password-reset/confirm/', {
+        token,
+        new_password: newPassword
+      });
+      if (response.data.success) {
+        return { success: true, message: response.data.message };
+      }
+      return { success: false, error: response.data.error || 'Password reset failed' };
+    } catch (error) {
+      console.error('Password reset failed:', error);
+      return {
+        success: false,
+        error: error.response?.data?.error || 'Password reset failed'
+      };
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const value = {
     user,
     login,
     register,
+    requestPasswordReset,
+    resetPassword,
     logout,
     loading,
     isAuthenticated: !!user


### PR DESCRIPTION
## Summary
- create ForgotPassword and ResetPassword pages
- handle password reset requests in auth context
- expose new routes in `App.js`
- update FAQ about password resets

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_68714f609948832485f9b908ac3a26be