### PR TITLE
Enable password reset emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,13 @@ AWS_S3_ARN=arn:aws:s3:::your-bucket-name
 AWS_STORAGE_BUCKET_NAME=your-bucket-name
 ALLOWED_HOSTS=[addCustomHostName],127.0.0.1,localhost
 DEBUG=False
+EMAIL_HOST=smtp.office365.com
+EMAIL_PORT=587
+EMAIL_HOST_USER=your-outlook-email
+EMAIL_HOST_PASSWORD=your-outlook-password
+EMAIL_USE_TLS=True
+DEFAULT_FROM_EMAIL="QuizCanvas <your-outlook-email>"
+FRONTEND_BASE_URL=https://quizcanvas.xyz
 ```
 
 ### External Services Setup
@@ -208,6 +215,8 @@ Configure these secrets in your GitHub repository settings:
 - `AWS_S3_ARN` - S3 bucket ARN
 - `AWS_STORAGE_BUCKET_NAME` - S3 bucket name
 - `REACT_APP_API_URL` - Backend API URL (Custom Host Name)
+- `EMAIL_HOST_USER` - Outlook email address used to send reset emails
+- `EMAIL_HOST_PASSWORD` - Password for the Outlook account
 
 **Auto-provided Secrets:**
 - `GITHUB_TOKEN` - Automatically provided by GitHub

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -203,3 +203,18 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024  # 10MB
 # JWT Configuration
 JWT_SECRET_KEY = config('JWT_SECRET_KEY', default=SECRET_KEY)
 
+# Email Configuration
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = os.getenv('EMAIL_HOST', 'smtp.office365.com')
+EMAIL_PORT = int(os.getenv('EMAIL_PORT', 587))
+EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER')
+EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD')
+EMAIL_USE_TLS = os.getenv('EMAIL_USE_TLS', 'True').lower() == 'true'
+DEFAULT_FROM_EMAIL = os.getenv(
+    'DEFAULT_FROM_EMAIL',
+    f"QuizCanvas <{EMAIL_HOST_USER or 'noreply@example.com'}>"
+)
+
+# Frontend URL for links in emails
+FRONTEND_BASE_URL = os.getenv('FRONTEND_BASE_URL', 'https://quizcanvas.xyz')
+

--- a/backend/quizapp/services/__init__.py
+++ b/backend/quizapp/services/__init__.py
@@ -1,2 +1,13 @@
-﻿# Services package for QuizCanvas
-# This file makes the services directory a Python package
+# Services package for QuizCanvas
+# Provides helper functions to access service instances
+
+from .email_service import EmailService
+
+_email_service = None
+
+
+def get_email_service() -> EmailService:
+    global _email_service
+    if _email_service is None:
+        _email_service = EmailService()
+    return _email_service

--- a/backend/quizapp/services/email_service.py
+++ b/backend/quizapp/services/email_service.py
@@ -1,0 +1,39 @@
+import logging
+from django.core.mail import EmailMultiAlternatives
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+class EmailService:
+    """Service for sending emails"""
+    def send_password_reset_email(self, to_email: str, reset_token: str) -> None:
+        reset_url = f"{settings.FRONTEND_BASE_URL}/reset-password?token={reset_token}"
+        subject = "QuizCanvas Password Reset"
+        text_body = f"""Hello,
+
+You requested a password reset for your QuizCanvas account.
+
+Click the following link to reset your password:
+{reset_url}
+
+This link will expire in 1 hour.
+
+If you didn't request this reset, please ignore this email.
+
+Best regards,
+QuizCanvas Team"""
+        html_body = (
+            f"<html><body><h2>Password Reset Request</h2>"
+            f"<p>Hello,</p>"
+            f"<p>You requested a password reset for your QuizCanvas account.</p>"
+            f"<p><a href=\"{reset_url}\" style=\"background-color: #4CAF50; color: white;"
+            f" padding: 10px 20px; text-decoration: none; border-radius: 5px;\">Reset Password</a></p>"
+            f"<p>This link will expire in 1 hour.</p>"
+            f"<p>If you didn't request this reset, please ignore this email.</p>"
+            f"<p>Best regards,<br>QuizCanvas Team</p></body></html>"
+        )
+        msg = EmailMultiAlternatives(subject, text_body, settings.DEFAULT_FROM_EMAIL, [to_email])
+        msg.attach_alternative(html_body, "text/html")
+        msg.send()
+        logger.info("Password reset email sent to %s", to_email)
+


### PR DESCRIPTION
## Summary
- configure email backend via environment variables
- add EmailService to send password reset emails
- update `reset_password_request` view to send reset link
- document email settings and secrets

## Testing
- `python3 -m py_compile backend/config/settings.py backend/quizapp/views.py backend/quizapp/services/email_service.py backend/quizapp/services/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6875932d6f488324a6f8a9aee03c91f7